### PR TITLE
Update build script, add index directory picker, and add to README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ import
 # Ignore nginx passwd file and logs
 nginx/.htpasswd
 nginx/logs/
+
+
+# Ignore some (probably useless) directory
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.0 as builder
+FROM gradle:8.5 as builder
 
 COPY build.gradle .
 COPY ./gradle.properties .
@@ -11,7 +11,7 @@ RUN gradle clean build
 
 FROM openjdk:8-jre
 
-COPY --from=builder /home/gradle/build/distributions/stacked-off-1.0.2.zip /stacked-off-1.0.2.zip
-RUN unzip /stacked-off-1.0.2.zip -d /root
+COPY --from=builder /home/gradle/build/distributions/stacked-off-1.0.3.zip /stacked-off-1.0.3.zip
+RUN unzip /stacked-off-1.0.3.zip -d /root
 
-CMD [ "/root/stacked-off-1.0.2/bin/stacked-off" ]
+CMD [ "/root/stacked-off-1.0.3/bin/stacked-off" ]

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ StackedOff uses the 'stack dump' data files made public by the Stack Exchange Ne
 
 <img src="https://github.com/tools4j/stacked-off/blob/master/resources/screenshot-search.png">
 
-# Installation (Docker)
-
 # Installation
 
 ## Pre-requisite
@@ -83,7 +81,7 @@ Re-run StackedOff.
 
 StackedOff can be built with JDK 8-21. To build it, run `./gradlew build` on MacOS or Linux or `gradlew.bat build` on Windows. After the build is done, it will be available in `./build/distributions/`.
 
-## Testing
+## Testing (Docker)
 
 StackedOff can also be built and ran via Docker. This is preferrable for testing since it's all one step, but does not produce easily distributable files.
 
@@ -97,7 +95,7 @@ Place your StackExchange archive files in the `import` directory and once on the
 
 > Don't forget downloading the [Sites.xml](https://archive.org/download/stackexchange/Sites.xml) file. Add it in `./import`.
 
-## Serving
+## Serving (Docker)
 
 Docker can also be used to make your computer into a kind of local StackExchange server. The "production" build adds basic_auth on `/admin` (add index) and `/rest/purgeSite` (remove index) endpoints, so that accounts can be added.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img height="64px" src="https://github.com/tools4j/stacked-off/blob/master/src/main/resources/webapp/stacked-off-white.png"/>
 
-StackedOff is a Stack Exchange site indexer and search engine.  It's
+StackedOff is a Stack Exchange site indexer and search engine. It's
 intended use is for people who wish to access Stack Exchange Network site(s), 
 e.g. <a href="https://stackoverflow.com">stackoverflow.com</a>, but do not have a reliable internet service.
 StackedOff uses the 'stack dump' data files made public by the Stack Exchange Network.
@@ -17,13 +17,13 @@ StackedOff uses the 'stack dump' data files made public by the Stack Exchange Ne
 
 ## Aquiring StackExchange Data Dumps
 
+**Important**: You must include in your download the Sites.xml file that is present in every data dump.
+
+**Important**: Once downloaded, do NOT unzip the 7z site files. StackedOff can only read from the archived site files.
+
 ### Simple download
 
 The latest StackExchange data dump can be downloaded <a href="https://ia600107.us.archive.org/27/items/stackexchange/">here</a>. Older data can be torrented (see next section).
-
-**Important**: You must include in your download the Sites.xml file that is present in every data dump.
-
-**Important**: Once downloaded, do NOT unzip the 7z site files.  StackedOff can only read from the archived site files.
 
 ### Torrenting
 
@@ -31,9 +31,9 @@ The latest StackExchange data dump can be downloaded <a href="https://ia600107.u
 2. Use your preferred BitTorrent client to download a, or part of a data dump.
 
 Note: Most BitTorrent clients allow you to pick and choose which files _within_ a Torrent that you
-wish to download.  You will probably want to limit the files that you download, as some of them can be 
-quite large.  Most of the sites are in individual 7z files.  Except for stackoverflow.com which is broken
-up into a few seperate archives.  If downloading stackoverflow.com, ensure you download the Posts, Users, and Comments files.
+wish to download. You will probably want to limit the files that you download, as some of them can be 
+quite large. Most of the sites are in individual 7z files. Except for stackoverflow.com which is broken
+up into a few seperate archives. If downloading stackoverflow.com, ensure you download the Posts, Users, and Comments files.
 
 ## Running StackedOff
 
@@ -42,14 +42,13 @@ up into a few seperate archives.  If downloading stackoverflow.com, ensure you d
 
 Launch a browser pointing at http://localhost and you should see the StackedOff GUI.
 
-(NOTE: Your browser must be ES6 compatible.  Please see the <a href="https://www.w3schools.com/js/js_es6.asp">table here for browser version compatibility</a>.)
+(NOTE: Your browser must be ES6 compatible. Please see the <a href="https://www.w3schools.com/js/js_es6.asp">table here for browser version compatibility</a>.)
 
 ### Configure index dir
 
-The first time that you run StackedOff you will be asked to specify an index directory.  This is where StackedOff
-will store it's indexes.  These indexes can get quite large if you are indexing large sites such as stackoverflow.com.
+The first time that you run StackedOff you will be asked to specify an index directory. This is where StackedOff will store it's indexes. These indexes can get quite large if you are indexing large sites such as stackoverflow.com.
 
-* Make sure you have enough disk space.  
+* Make sure you have enough disk space. 
 * It is preferable to use a local disk, as this will dramatically impact the speed of StackedOff.
 * It is preferable to use an SSD, as this will also impact the speed of StackedOff.
 
@@ -58,11 +57,11 @@ will store it's indexes.  These indexes can get quite large if you are indexing 
 Assuming you have downloaded a Stack Exchange site:
 
 1. click on the 'Add Site' button.
-2. Enter the path that contains the 7z file(s) and Sites.xml file that you previously downloaded.  Click 'Next'
+2. Enter the path that contains the 7z file(s) and Sites.xml file that you previously downloaded. Click 'Next'
 3. Select the site(s) that you wish to index.
 4. Click 'Next'
 
-Indexing can take some time.  On my laptop (7th Gen i5, with SSD) indexing <a href="stackoverflow.com">stackoverflow.com</a> takes about 4 hours.
+Indexing can take some time. On my laptop (7th Gen i5, with SSD) indexing <a href="stackoverflow.com">stackoverflow.com</a> takes about 4 hours.
 
 ### Search
 
@@ -110,7 +109,7 @@ htpasswd -m ./nginx/.htpasswd admin
 
 # Acknowledgments
 
-The guys at <a href="https://stackexchange.com/">stackexchange.com</a>.  Who not only revolutionized the 
+The guys at <a href="https://stackexchange.com/">stackexchange.com</a>. Who not only revolutionized the 
 technical Q&A space, but also in the spirit of 'openness' admirably continue to allow free access to all of their
 Q&A data for all of their sites.
 

--- a/README.md
+++ b/README.md
@@ -9,65 +9,7 @@ StackedOff uses the 'stack dump' data files made public by the Stack Exchange Ne
 
 # Installation (Docker)
 
-## Build and run (dev / test)
-
-Let's build and run the service :
-
-```bash
-docker-compose up -d --build
-```
-
-Go on `localhost:8080`
-
-Place your StackExchange archive files in the `./import` directory and once on the web interface, enter `/import` as _Index directory_.
-
-> Don't forget downloading the [Sites.xml](https://archive.org/download/stackexchange/Sites.xml) file. Add it in `./import`.
-
-## Build and run (production)
-
-Production adds basic_auth on `/admin` (add index) and `/rest/purgeSite` (remove index) endpoints
-
-Create a user and password with :
-
-```bash
-touch ./nginx/.htpasswd
-htpasswd -m ./nginx/.htpasswd admin
-# A password will be asked for the "admin" user
-# You can add multiple accounts
-```
-
-> This may require an `apt-get install apache2-utils`
-
-Let's build and run the service :
-
-```bash
-docker-compose -f prod.docker-compose.yml up -d --build
-```
-
-Go on `localhost:8080`
-
-Place your StackExchange archive files in the `./import` directory and once on the web interface, enter `/import` as _Index directory_.
-
-> Don't forget downloading the [Sites.xml](https://archive.org/download/stackexchange/Sites.xml) file. Add it in `./import`.
->
-> Example :
-> 
-> ```
-> wget https://ia600107.us.archive.org/27/items/stackexchange/Sites.xml
-> wget https://ia600107.us.archive.org/27/items/stackexchange/Stackoverflow.com-Posts.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-Badges.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-Comments.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-PostHistory.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-PostLinks.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-Tags.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-Users.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/stackoverflow.com-Votes.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/french.stackexchange.com.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/crypto.stackexchange.com.7z
-> wget https://ia600107.us.archive.org/27/items/stackexchange/unix.stackexchange.com.7z
-> ```
-
-# Installation (classic)
+# Installation
 
 ## Pre-requisite
 
@@ -77,17 +19,23 @@ Place your StackExchange archive files in the `./import` directory and once on t
 
 ## Aquiring StackExchange Data Dumps
 
-1. Get the 'BitTorrent Infohash' from <a href="https://meta.stackexchange.com/questions/224873/all-stack-exchange-data-dumps">here</a>.
+### Simple download
+
+The latest StackExchange data dumps can be downloaded <a href="https://ia600107.us.archive.org/27/items/stackexchange/">here</a>. Older dumps can be torrented (see next section).
+
+**Important**: You must include in your download the Sites.xml file that is present in every data dump.
+
+**Important**: Once downloaded, do NOT unzip the 7z site files.  StackedOff can only read from the archived site files.
+
+### Torrenting
+
+1. Get the 'BitTorrent Infohash' from <a href="https://meta.stackexchange.com/questions/224873/all-stack-exchange-data-dumps/224922#224922">here</a>.
 2. Use your preferred BitTorrent (e.g. uTorrent) client to download a, or part of a Data Dump.
 
 Note: Most BitTorrent clients allow you to pick and choose which files _within_ a Torrent that you
 wish to download.  You will probably want to limit the files that you download, as some of them can be 
 quite large.  Most of the sites are in individual 7z files.  Except for stackoverflow.com which is broken
 up into a few seperate archives.  If downloading stackoverflow.com, ensure you download the Posts, Users, and Comments files.
-
-**Important**: You must include in your download the Sites.xml file that is present in every data dump.
-
-**Important**: Once downloaded, do NOT unzip the 7z site files.  StackedOff can only read from the archived site files.
 
 ## Running StackedOff
 
@@ -130,6 +78,39 @@ To change this, edit the file in your home directory .stackedoff/app.properties,
 `port=8080`
 
 Re-run StackedOff.
+
+## Building
+
+StackedOff can be built with JDK 8-21. To build it, run `./gradlew build` on MacOS or Linux or `gradlew.bat build` on Windows. After the build is done, it will be available in `./build/distributions/`.
+
+## Testing
+
+StackedOff can also be built and ran via Docker. This is preferrable for testing since it's all one step, but does not produce easily distributable files.
+
+```bash
+docker-compose up -d --build
+```
+
+Go on `localhost:8080`
+
+Place your StackExchange archive files in the `import` directory and once on the web interface, enter `/import` as _Index directory_.
+
+> Don't forget downloading the [Sites.xml](https://archive.org/download/stackexchange/Sites.xml) file. Add it in `./import`.
+
+## Serving
+
+Docker can also be used to make your computer into a kind of local StackExchange server. The "production" build adds basic_auth on `/admin` (add index) and `/rest/purgeSite` (remove index) endpoints, so that accounts can be added.
+
+Create a user and password with :
+
+```bash
+touch ./nginx/.htpasswd
+htpasswd -m ./nginx/.htpasswd admin
+# A password will be asked for the "admin" user
+# You can add multiple accounts
+```
+
+> This may require an `apt-get install apache2-utils`
 
 # Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ StackedOff uses the 'stack dump' data files made public by the Stack Exchange Ne
 
 ### Simple download
 
-The latest StackExchange data dumps can be downloaded <a href="https://ia600107.us.archive.org/27/items/stackexchange/">here</a>. Older dumps can be torrented (see next section).
+The latest StackExchange data dump can be downloaded <a href="https://ia600107.us.archive.org/27/items/stackexchange/">here</a>. Older data can be torrented (see next section).
 
 **Important**: You must include in your download the Sites.xml file that is present in every data dump.
 
@@ -28,7 +28,7 @@ The latest StackExchange data dumps can be downloaded <a href="https://ia600107.
 ### Torrenting
 
 1. Get the 'BitTorrent Infohash' from <a href="https://meta.stackexchange.com/questions/224873/all-stack-exchange-data-dumps/224922#224922">here</a>.
-2. Use your preferred BitTorrent (e.g. uTorrent) client to download a, or part of a Data Dump.
+2. Use your preferred BitTorrent client to download a, or part of a data dump.
 
 Note: Most BitTorrent clients allow you to pick and choose which files _within_ a Torrent that you
 wish to download.  You will probably want to limit the files that you download, as some of them can be 
@@ -51,7 +51,7 @@ will store it's indexes.  These indexes can get quite large if you are indexing 
 
 * Make sure you have enough disk space.  
 * It is preferable to use a local disk, as this will dramatically impact the speed of StackedOff.
-* It is preferable to use an SSD disk, as this will also impact the speed of StackedOff.
+* It is preferable to use an SSD, as this will also impact the speed of StackedOff.
 
 ### Load a site
 
@@ -79,11 +79,11 @@ Re-run StackedOff.
 
 ## Building
 
-StackedOff can be built with JDK 8-21. To build it, run `./gradlew build` on MacOS or Linux or `gradlew.bat build` on Windows. After the build is done, it will be available in `./build/distributions/`.
+StackedOff can be built with JDK 8-21. To build it, run `./gradlew build` on a Unix-like system or `gradlew.bat build` on Windows. After the build is done, it is available in `./build/distributions/`.
 
 ## Testing (Docker)
 
-StackedOff can also be built and ran via Docker. This is preferrable for testing since it's all one step, but does not produce easily distributable files.
+StackedOff can also be built and ran via Docker. This is preferrable for testing since it's all one step, but not for production, as it does not produce distributable files.
 
 ```bash
 docker-compose up -d --build
@@ -92,8 +92,6 @@ docker-compose up -d --build
 Go on `localhost:8080`
 
 Place your StackExchange archive files in the `import` directory and once on the web interface, enter `/import` as _Index directory_.
-
-> Don't forget downloading the [Sites.xml](https://archive.org/download/stackexchange/Sites.xml) file. Add it in `./import`.
 
 ## Serving (Docker)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.7.20'
 
     repositories {
         mavenCentral()
@@ -28,32 +28,32 @@ java {
 }
 
 application {
-    mainClassName = 'org.tools4j.stacked.web.Server'
+    mainClass.set('org.tools4j.stacked.web.Server')
 }
 
 dependencies {
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
-    compile("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1")
-    compile("org.apache.lucene:lucene-core:8.1.1")
-    compile("org.apache.lucene:lucene-queryparser:8.1.1")
-    compile("org.apache.lucene:lucene-highlighter:8.1.1")
-    compile("org.apache.lucene:lucene-join:8.1.1")
-    compile("com.fasterxml.jackson.core:jackson-core:2.9.8")
-    compile("com.fasterxml.jackson.core:jackson-annotations:2.9.8")
-    compile("com.fasterxml.jackson.core:jackson-databind:2.9.8")
-    compile("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.8")
-    compile("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8")
-    compile("io.ktor:ktor-server-netty:$ktor_version")
-    compile("io.ktor:ktor-gson:$ktor_version")
-    compile("ch.qos.logback:logback-classic:1.2.3")
-    compile "io.github.microutils:kotlin-logging:1.6.20"
-    compile("net.sf.sevenzipjbinding:sevenzipjbinding:9.20-2.00beta")
-    compile "com.github.tulskiy:jkeymaster:1.2"
-    compile "com.airhacks:afterburner.fx:1.6.0"
-    runtime("net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:9.20-2.00beta")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1")
+    implementation("org.apache.lucene:lucene-core:8.1.1")
+    implementation("org.apache.lucene:lucene-queryparser:8.1.1")
+    implementation("org.apache.lucene:lucene-highlighter:8.1.1")
+    implementation("org.apache.lucene:lucene-join:8.1.1")
+    implementation("com.fasterxml.jackson.core:jackson-core:2.9.8")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:2.9.8")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.9.8")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.8")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8")
+    implementation("io.ktor:ktor-server-netty:$ktor_version")
+    implementation("io.ktor:ktor-gson:$ktor_version")
+    implementation("ch.qos.logback:logback-classic:1.2.3")
+    implementation "io.github.microutils:kotlin-logging:1.6.20"
+    implementation("net.sf.sevenzipjbinding:sevenzipjbinding:9.20-2.00beta")
+    implementation "com.github.tulskiy:jkeymaster:1.2"
+    implementation "com.airhacks:afterburner.fx:1.6.0"
+    runtimeOnly("net.sf.sevenzipjbinding:sevenzipjbinding-all-platforms:9.20-2.00beta")
     implementation 'org.tukaani:xz:1.8'
     
-    testCompile("org.assertj:assertj-core:3.11.1")
-    testCompile("org.junit.jupiter:junit-jupiter-api:5.3.1")
-    testCompile("org.junit.jupiter:junit-jupiter-engine:5.3.1")
+    testImplementation("org.assertj:assertj-core:3.11.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-engine:5.3.1")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 }
 
 group = "org.tools4j"
-version = "1.0.2"
+version = "1.0.3"
 
 def ktor_version = "1.1.3"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/org/tools4j/stacked/web/Server.kt
+++ b/src/main/kotlin/org/tools4j/stacked/web/Server.kt
@@ -51,6 +51,7 @@ class Server {
         }
 
         private fun Application.mainServer() {
+            var chooser = JFileChooser()
             val loadInProgress = AtomicReference<JobStatus>(NullJobStatus())
 
             install(DefaultHeaders) {
@@ -211,12 +212,15 @@ class Server {
                 }
 
                 get("/rest/directoryPicker") {
-                    val chooser = JFileChooser()
+                    if (chooser === null) chooser = JFileChooser();
                     chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY)
 
+                    chooser.setVisible(true)
                     val returnVal = chooser.showOpenDialog(null)
-                    if (returnVal == JFileChooser.APPROVE_OPTION) call.respond(chooser.getSelectedFile().getAbsolutePath())
-                    else call.respond("")
+                    val selectedFile = chooser.getSelectedFile();
+                    if (selectedFile != null) call.respond(HttpStatusCode.OK, selectedFile.getAbsolutePath())
+                    else call.respond(HttpStatusCode.InternalServerError)
+                    chooser.setVisible(false)
                 }
 
 

--- a/src/main/kotlin/org/tools4j/stacked/web/Server.kt
+++ b/src/main/kotlin/org/tools4j/stacked/web/Server.kt
@@ -211,10 +211,7 @@ class Server {
                 }
 
                 get("/rest/directoryPicker") {
-                    val home = System.getProperty("user.home")
-                    val downloads = File(home, "Downloads")
-
-                    val chooser = JFileChooser(downloads)
+                    val chooser = JFileChooser()
                     chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY)
 
                     val returnVal = chooser.showOpenDialog(null)

--- a/src/main/resources/webapp/app.js
+++ b/src/main/resources/webapp/app.js
@@ -123,13 +123,20 @@ function showAdmin(parentIndexDir, message){
                 be on disk, but you won't see them in StackedOff.  To see them again, set the directory back to where
                 it was pointing to previously.</p>
                 <br/>
-                <p><i>(This cannot be a file chooser due to browser security restrictions.)</i></p>
+                <p><i>(The file picker does not consistently function. If it doesn't show, the best course of action is to close and rerun StackedOff.)</i></p>
                 <br/>
                 <div class="div-load-sites">
                     <input id="index-parent-dir"
                             class="wide-text-input text-input"
                             type="text"
                             value="${parentIndexDir}"/>
+                    <input id="index-parent-dir-picker" type="button" value="Open Picker" onclick="fetch('/rest/directoryPicker').then((response) => {
+                        if (response.ok) {
+                            response.text().then((text) => {
+                                $('#index-parent-dir')[0].value = text;
+                            });
+                        }
+                    });">
                 </div>
                 <br/>
                 <input id="sites-xml-chosen-next-button"

--- a/src/main/resources/webapp/app.js
+++ b/src/main/resources/webapp/app.js
@@ -119,8 +119,8 @@ function showAdmin(parentIndexDir, message){
     showMessage(message)
     const markup = `<h1>Index Directory</h1>
                 <p>Please select the directory where your indexes are/will be stored.</p>
-                <p>If you already have sites loaded, and you change this directory.  Your indexes will still 
-                be on disk, but you won't see them in StackedOff.  To see them again, set the directory back to where
+                <p>If you already have sites loaded, and you change this directory. Your indexes will still 
+                be on disk, but you won't see them in StackedOff. To see them again, set the directory back to where
                 it was pointing to previously.</p>
                 <br/>
                 <p><i>(The file picker does not consistently function. If it doesn't show, the best course of action is to close and rerun StackedOff.)</i></p>
@@ -428,7 +428,7 @@ function showSites(indexedSites){
     if(indexedSites.length == 0){
         const markup = `
                 <br/>
-                <span>You have no sites loaded.  Click here to load sites from a stackdump download</span>
+                <span>You have no sites loaded. Click here to load sites from a stackdump download</span>
                 <br/><br/>
                 <input type="button" onclick="router.navigate('/load/chooseSitesXmlFile')" value="Load new site(s)"/>
                 `


### PR DESCRIPTION
This pull request aims to update the build script to be compatible with and use Gradle 8.5, add a semi-functional (`JFileChooser` isn't very reliable) directory chooser for picking an index directory, and make some changes to the README (adding information about how to build and what JDK versions StackedOff can be built with and how to download data without BitTorrent).